### PR TITLE
Make fix

### DIFF
--- a/src/topology-read/model/rocketfuel-topology-reader.cc
+++ b/src/topology-read/model/rocketfuel-topology-reader.cc
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <regex.h>
 
+//creates make issues
 //#include <pcre2posix.h>
 
 #include "ns3/log.h"

--- a/src/topology-read/model/rocketfuel-topology-reader.cc
+++ b/src/topology-read/model/rocketfuel-topology-reader.cc
@@ -22,9 +22,9 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <regex.h>
 
-
-#include <pcre2posix.h>
+//#include <pcre2posix.h>
 
 #include "ns3/log.h"
 #include "ns3/unused.h"


### PR DESCRIPTION
after a make is issued from the initial configuration. An error is given due to no regex.h support and no pcre2posix.h